### PR TITLE
feat: optimize card show/hide behavior

### DIFF
--- a/src/contentScript/lingoCard.tsx
+++ b/src/contentScript/lingoCard.tsx
@@ -114,11 +114,17 @@ export default function ContentScriptApp() {
     },
     [showCardAndPosition]
   );
+  const mouseoutCollectCallback = useCallback(() => {
+    if (mouseoverCollectTimer.current && ! cardShow) {
+      clearTimeout(mouseoverCollectTimer.current);
+    }
+  }, [cardShow]);
   const onmouseenterCard = useCallback(() => {
     hideCardTimer.current && clearTimeout(hideCardTimer.current);
-  }, []);  
+  }, []);
   useTreeWalker({
-    mouseoverCallback: mouseoverCollectCallback
+    mouseoverCallback: mouseoverCollectCallback,
+    mouseoutCallback: mouseoutCollectCallback,
   })
   useEffect(() => {
     const handleMouseUp = async function (event: MouseEvent) {


### PR DESCRIPTION
Added a mouseout callback to clear the card show timeout if the card is not currently shown. This prevents the card from unexpectedly appearing when the user accidentally hovers over the highlight word.